### PR TITLE
ci: add linter action for PRs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,21 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Checklist

* [x] Have you followed the guidelines in our [CONTRIBUTING](../../blob/master/.github/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass lint and tests?
* [x] Does your commit and commit message style matches our [requested structure](../../blob/master/.github/CONTRIBUTING.md#memo-writing-commit-messages)?

# Description

## 🔥 What?
Adds a GitHub action to enforce semantic pull requests, based on the conventional commits spec.

## 😲 How?
Uses the GitHub action: [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request).

## 🤔 Why?
Having conventions on PRs will make it easier to automate analytics for future work.

## 📸 Screenshots (if applicable)
<!-- Show-off your work -->

## 💭 Anything Else?
Nope.
