### PR TITLE
ci: Fix indentation for commit options

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     schedule:
       interval: "weekly"
     commit_message:
-          prefix: "chore"
-          include_scope: true
+      prefix: "chore"
+      include_scope: true


### PR DESCRIPTION
# Checklist

* [x] Have you followed the guidelines in our [CONTRIBUTING](../../blob/master/.github/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass lint and tests?
* [x] Does your commit and commit message style matches our [requested structure](../../blob/master/.github/CONTRIBUTING.md#memo-writing-commit-messages)?

# Description

## 🔥 What?
Fixes indentation for commit message options in dependabot config.

## 😲 How?
<!-- How does it accomplish that? -->

## 🤔 Why?
<!-- Why does it need to accomplish that? -->

## 📸 Screenshots (if applicable)
<!-- Show-off your work -->

## 💭 Anything Else?
Nope.
