### PR TITLE
feat: Enable signed keyboard input

### DIFF
--- a/lib/widgets/coordinates_input_form.dart
+++ b/lib/widgets/coordinates_input_form.dart
@@ -44,7 +44,7 @@ class CoordinatesInputForm extends StatelessWidget {
                   ),
                 ),
                 keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
+                    const TextInputType.numberWithOptions(decimal: true, signed: true),
                 validator: (String? value) {
                   if (InputValidation.latitudeValidatorPattern.hasMatch(value!)) {
                     return null;
@@ -69,7 +69,7 @@ class CoordinatesInputForm extends StatelessWidget {
                   ),
                 ),
                 keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
+                    const TextInputType.numberWithOptions(decimal: true, signed: true),
                 validator: (String? value) {
                   if (InputValidation.longitudeValidatorPattern
                       .hasMatch(value!)) {


### PR DESCRIPTION
# Checklist

* [x] Have you followed the guidelines in our [CONTRIBUTING](../../blob/master/.github/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass lint and tests?
* [x] Does your commit and commit message style matches our [requested structure](../../blob/master/.github/CONTRIBUTING.md#memo-writing-commit-messages)?

# Description

## 🔥 What?
Enables signed keyboard for iOS (and Android).

## 😲 How?
By specifying `signed: true` within the input type.

## 🤔 Why?
On Android, signed keyboard (having - sign) is shown by default when using `TextInputType.numberWithOptions`. But on iOS, there's no signage available. Coordinates are often negative, so it is preventing iOS users from accurate manual entry of coordinates.

## 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/0a49a8e4-7501-4fe4-8fa6-6e64600521f1)

## 💭 Anything Else?
Nope.
