### PR TITLE
feat: Enable device compass

### DIFF
--- a/lib/pages/map_page.dart
+++ b/lib/pages/map_page.dart
@@ -1,4 +1,5 @@
 import 'dart:developer' as developer;
+import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_compass/flutter_compass.dart';

--- a/lib/pages/map_page.dart
+++ b/lib/pages/map_page.dart
@@ -1,6 +1,7 @@
 import 'dart:developer' as developer;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_compass/flutter_compass.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:geolocator/geolocator.dart';

--- a/lib/pages/map_page_state.dart
+++ b/lib/pages/map_page_state.dart
@@ -219,11 +219,34 @@ class MapPageState extends State<MapPage> {
                   _onCameraMove(position),
               onCameraIdle: _onCameraIdle,
             ),
-            const Center(
-              child: Icon(
-                TablerIcons.circle_dot,
-                size: AppDimensions.iconSizeLg,
-                color: Colors.black,
+            Center(
+              child: StreamBuilder<CompassEvent>(
+                stream: FlutterCompass.events,
+                builder: (BuildContext context,
+                    AsyncSnapshot<CompassEvent> snapshot) {
+                  if (snapshot.hasError) {
+                    return Icon(
+                      TablerIcons.circle_dot,
+                      size: AppDimensions.iconSizeLg,
+                      color: Colors.black,
+                    );
+                  }
+
+                  if (snapshot.connectionState == ConnectionState.waiting ||
+                      !snapshot.hasData) {
+                    return CircularProgressIndicator();
+                  }
+
+                  double heading = snapshot.data!.heading ?? 0;
+                  return Transform.rotate(
+                    angle: heading * (3.141592653589793 / 180),
+                    child: Icon(
+                      TablerIcons.circle_arrow_up,
+                      size: AppDimensions.iconSizeLg,
+                      color: Colors.black,
+                    ),
+                  );
+                },
               ),
             ),
           ],

--- a/lib/pages/map_page_state.dart
+++ b/lib/pages/map_page_state.dart
@@ -240,7 +240,7 @@ class MapPageState extends State<MapPage> {
 
                   double heading = snapshot.data!.heading ?? 0;
                   return Transform.rotate(
-                    angle: heading * (3.141592653589793 / 180),
+                    angle: heading * (pi / 180),
                     child: Icon(
                       TablerIcons.circle_arrow_up,
                       size: AppDimensions.iconSizeLg,

--- a/lib/pages/map_page_state.dart
+++ b/lib/pages/map_page_state.dart
@@ -209,6 +209,7 @@ class MapPageState extends State<MapPage> {
             GoogleMap(
               onMapCreated: _onMapCreated,
               compassEnabled: true,
+              rotateGesturesEnabled: false,
               myLocationButtonEnabled: false,
               polylines: _polylines,
               mapType: _currentMapType,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -219,6 +219,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_compass:
+    dependency: "direct main"
+    description:
+      name: flutter_compass
+      sha256: "1b4d7e6c95a675ec8482b5c9c9ccf1ebf0ced3dbec59dce28ad609da953de850"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   flutter_keyboard_visibility:
     dependency: transitive
     description:
@@ -1008,5 +1016,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   introduction_screen: ^3.1.14
   shared_preferences: ^2.3.5
   in_app_review: ^2.0.10
+  flutter_compass: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/test/map_page_test.dart
+++ b/test/map_page_test.dart
@@ -19,7 +19,8 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle();
+      // Allow the map to render
+      await tester.pump(const Duration(seconds: 1));
     }
 
     testWidgets('Toggles map type when the toggle button is pressed',
@@ -32,7 +33,7 @@ void main() {
 
       // Tap the toggle button
       await tester.tap(find.byIcon(TablerIcons.map));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 300)); // Add a short delay for the tap action
 
       // Verify map type is changed to hybrid
       final GoogleMap googleMapAfterFirstTap =
@@ -41,7 +42,7 @@ void main() {
 
       // Tap the toggle button again
       await tester.tap(find.byIcon(TablerIcons.map));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 300)); // Add a short delay for the tap action
 
       // Verify map type is changed back to normal
       final GoogleMap googleMapAfterSecondTap =


### PR DESCRIPTION
# Checklist

* [x] Did you double check which branch your PR is merging changes to?
* [x] Have you followed the guidelines in our [CONTRIBUTING](../../blob/master/.github/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass lint and tests?
* [x] Does your commit and commit message style matches our [requested structure](../../blob/master/.github/CONTRIBUTING.md#memo-writing-commit-messages)?

# Description

## 🔥 What?
Enables device compass and rotates the center icon accordingly to make Qibla finding easier/more intuitive for some people. Disables map rotation since map is not tied to the compass logic (yet) and may cause confusion if people don't notice the compass icon that pops up on the top left of the map.

## 😲 How?
By building a stream reading compass events provided via `flutter_compass`, then converting the degree angle to radians and using it to rotate the center icon. If compass fails, icon falls back to ambiguous circle with a dot.

## 🤔 Why?
As requested in #110 and by multiple other people. Hope the app now helps you people out even more!

## 📸 Screenshots (if applicable)
<!-- Show-off your work -->
![Screenshot_20250120-152611-min](https://github.com/user-attachments/assets/c7b164c7-1902-4193-94cf-95d9a26d33e6)
_sleek_

## 💭 Anything Else?
Nope.
