### PR TITLE
feat: Update icon color to blue accent

### DIFF
--- a/lib/pages/map_page_state.dart
+++ b/lib/pages/map_page_state.dart
@@ -250,7 +250,7 @@ class MapPageState extends State<MapPage> {
                     angle: heading * (pi / 180),
                     child: UserLocationIcon(
                       primaryColor:
-                          _isMapCenteredOnUser ? Colors.blue : Colors.grey,
+                          _isMapCenteredOnUser ? Colors.blueAccent : Colors.grey,
                     ),
                   );
                 },


### PR DESCRIPTION
# Checklist

* [x] Did you double check which branch your PR is merging changes to?
* [x] Have you followed the guidelines in our [CONTRIBUTING](../../blob/master/.github/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass lint and tests?
* [x] Does your commit and commit message style matches our [requested structure](../../blob/master/.github/CONTRIBUTING.md#memo-writing-commit-messages)?

# Description

## 🔥 What?
Update the color of the centered-user-location-icon thingy when it's centered on the user location.

## 😲 How?
blue -> blueAccent

## 🤔 Why?
Looks slightly more standard. Good enough for the time-being.

## 📸 Screenshots (if applicable)
<img width="1080" height="2424" alt="Screenshot_1757034673" src="https://github.com/user-attachments/assets/66ac748d-6230-43fe-a03e-a2918cc54c6d" />


## 💭 Anything Else?
Nope.
